### PR TITLE
Run the contents report weekly, and fix the utils checkout

### DIFF
--- a/.github/workflows/report.yml
+++ b/.github/workflows/report.yml
@@ -1,7 +1,18 @@
 name: generate Tools Platform Ecosystem contents report
 
-on: 
+on:
+  # Weekly, six hours after the Sunday 00:00 UTC source imports in import.yaml,
+  # so the report describes the metadata those imports have just landed.
+  schedule:
+    - cron: "0 6 * * 0"
   workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: contents-report
+  cancel-in-progress: false
 
 jobs:
   generate-stats:
@@ -12,24 +23,21 @@ jobs:
         path: content
     - uses: actions/checkout@v4
       with:
-        repository: bio-tools/content-ecosystem-utils
-        path: content-ecosystem-utils
+        repository: research-software-ecosystem/utils
+        path: utils
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
     - name: Install dependencies
       run:
-        pip install -r ${{ github.workspace }}/content-ecosystem-utils/scripts/stats/requirements.txt
+        pip install -r ${{ github.workspace }}/utils/scripts/stats/requirements.txt
     - name: generate report
       run: |
-        cd ${{ github.workspace }}/content-ecosystem-utils/scripts/stats
+        cd ${{ github.workspace }}/utils/scripts/stats
         python ecosystem.py ${{ github.workspace }}/content
     - name: commit new report
-      env:
-        GITHUB_USER: ${{ secrets.GITHUB_USER }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |  
+      run: |
         cd ${{ github.workspace }}/content
         git config --local user.email "tpe-bot@github.com"
         git config --local user.name "Tools Platform Ecosystem bot"


### PR DESCRIPTION
Companion to research-software-ecosystem/utils#57, which fixes the report script itself. **Merge that one first, then this.**

### Why

The report has only ever been runnable by hand — `on:` listed `workflow_dispatch` and no `schedule`. Nobody dispatched it, so:

| File | Last written |
|---|---|
| `report/global_upset.png`, `summary.md`, `detailed_counts.md` | **2023-07-06** |
| `report/ecosystem.md` | **2020-10-12** |

The single run in retained history, on **2026-03-30**, **failed** — and because the job is manual-only and nothing consumes its output, the failure went unnoticed. A schedule means a break shows up in the Actions tab instead of quietly freezing the numbers for three years.

### Changes

- **`schedule: "0 6 * * 0"`** — weekly, six hours after the Sunday 00:00 UTC source imports in `import.yaml`, so the report describes the metadata those imports have just landed.
- **Check out `research-software-ecosystem/utils`** instead of `bio-tools/content-ecosystem-utils`. That repo was renamed; the step only still worked because GitHub follows the redirect. Local path becomes `utils` to match.
- **`permissions: contents: write`** — so the commit step does not depend on the repository-wide default token permissions.
- **`concurrency` group** — so a manual dispatch and the schedule cannot race each other into a push conflict.
- **Drop the unused `GITHUB_USER` / `GITHUB_TOKEN` env block** — the push uses the credentials `actions/checkout` persists, and `secrets.GITHUB_USER` was never referenced by anything.

### Notes

- The job does not pass `--detailed`, so it will no longer commit `report/detailed_counts.md`. That file is 11.1 MB against current content, and committing it weekly would add roughly 0.5 GB/year to a repo already at ~5.4 GB. Rationale and the flag are in utils#57 — easy to add back here if you would rather keep it.
- `report/ecosystem.md` has not been produced by the script since 2020 and is untouched here. Worth deleting separately if it is genuinely orphaned.
- The `content` checkout is unchanged, so runtime and disk are as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
