### PR TITLE
Import WorkflowHub alongside the other sources

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -309,6 +309,44 @@ jobs:
         commit_message: import BioConductor tools data
         branch: bioconductor-import-branch
         create_branch: true
+  workflowhub:
+    runs-on: ubuntu-latest
+    outputs:
+      commit_hash: ${{ steps.commit-and-push-workflowhub.outputs.commit_hash }}
+    steps:
+    - name: checkout contents repository
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.ref }}
+    - name: delete previous import branch
+      run: |
+        branch_name="workflowhub-import-branch"
+        # Check if the branch exists on the remote repository
+        if git rev-parse --verify --quiet "origin/$branch_name"; then
+          # The branch exists, so it can be safely deleted
+          git push origin --delete "$branch_name"
+          echo "Branch $branch_name has been deleted."
+        else
+          # The branch does not exist
+          echo "Branch $branch_name does not exist on the remote repository."
+        fi
+    - name: Create and checkout feature branch
+      run: git checkout -b workflowhub-import-branch
+    - name: import WorkflowHub data from server
+      uses: research-software-ecosystem/utils/workflowhub-import@main
+      with:
+        repo-user: ${{ secrets.GITHUB_USER }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Commit and Push Changes
+      id: commit-and-push-workflowhub
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_user_name: Tools Platform Ecosystem bot
+        commit_user_email: tpe-bot@github.com
+        commit_author: Tools Platform Ecosystem bot <tpe-bot@github.com>
+        commit_message: import WorkflowHub data
+        branch: workflowhub-import-branch
+        create_branch: true
   merge-imports:
     runs-on: ubuntu-latest
     needs:
@@ -320,6 +358,7 @@ jobs:
       - galaxytool
       - debian-med
       - bioconductor
+      - workflowhub
     if: always()
     steps:
       - name: Checkout Repository
@@ -349,6 +388,7 @@ jobs:
           merge_branch_if_exists "galaxytool-import-branch"
           merge_branch_if_exists "debianmed-import-branch"
           merge_branch_if_exists "bioconductor-import-branch"
+          merge_branch_if_exists "workflowhub-import-branch"
           git push origin master
   bioconductor-to-biotools:
     runs-on: ubuntu-latest
@@ -442,4 +482,5 @@ jobs:
           delete_branch_if_exists "galaxytool-import-branch"
           delete_branch_if_exists "debianmed-import-branch"
           delete_branch_if_exists "bioconductor-import-branch"
+          delete_branch_if_exists "workflowhub-import-branch"
           delete_branch_if_exists "bioconductor-to-biotools-branch"


### PR DESCRIPTION
Adds a `workflowhub` job to the weekly import, running **in parallel** with the eight existing importers (`biotools`, `openebench`, `bioconda`, `biii`, `biocontainers`, `galaxytool`, `debian-med`, `bioconductor`). It follows the `biotools` job shape exactly: delete any stale import branch → create `workflowhub-import-branch` → run the composite action → commit and push via `git-auto-commit-action`.

> [!IMPORTANT]
> Depends on research-software-ecosystem/utils#52, which adds the `workflowhub-import` action. **Merge that first.** Until it lands, `research-software-ecosystem/utils/workflowhub-import@main` does not resolve and this job fails. `merge-imports` is `if: always()`, so the other importers would still merge — but there is no reason to land this first.

### Wiring

The job alone is not enough. Three further edits are needed, without which the branch is created but never consumed:

| Edit | Location | Without it |
|---|---|---|
| `- workflowhub` | `merge-imports.needs` | merge runs before the import finishes |
| `merge_branch_if_exists "workflowhub-import-branch"` | `merge-imports` | data is committed to a branch and never reaches `master` |
| `delete_branch_if_exists "workflowhub-import-branch"` | `clean-branches` | a stale branch accumulates every week |

Verified by parsing the workflow: 9 parallel importer jobs, all 9 present in `merge-imports.needs`, and every branch created by a `git checkout -b` is both merged and deleted. (The parser also flags `bioconductor-to-biotools-branch` as never merged in `merge-imports` — that is pre-existing and handled by the separate `merge-bioconductor` job, not something this PR touches.)

### What it changes about the commons

This makes **WorkflowHub a per-tool source for the first time**. Today it deposits only the bulk Turtle dumps under `datasets/` and nothing under `data/`, which is why it has no row in `report/global_upset.png`. Once this runs, `scripts/stats/ecosystem.py` should gain `("WorkflowHub", ("*.workflowhub.json",))` in `NATIVE_SOURCES`, replacing the comment there that documents why WorkflowHub is absent — it would become the ninth source in the report.

### Runtime

The importer walks ~1,500 workflows at roughly one API request plus a 0.2 s pause each, so expect **12–15 minutes** — longer than most sibling jobs. Since they run in parallel it should not extend the overall import much.

### Expected yield

From testing the importer against 150 workflows on a full checkout: tool extraction is effectively Galaxy-only (Galaxy 22 workflows → 35 bio.tools IDs, but Nextflow 95 → 21 and Snakemake 7 → 0), and after utils#52's strictness fix only curated bio.tools annotations and galaxy_codex mappings count. So the first run should add a modest number of `data/*/*.workflowhub.json` files rather than thousands. Coverage grows as WorkflowHub annotations and the galaxy_codex `bio.tool ID` column fill in — only 625 of galaxy_codex's 1,840 entries currently carry one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
