### PR TITLE
Stop the merge jobs pushing a stale master

### DIFF
--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -363,6 +363,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          # Checkout defaults to the run's head SHA rather than the current tip
+          # of master, which goes stale as soon as anything else pushes.
+          ref: master
       - name: Merge feature branches
         run: |
           git config --local user.email "tpe-bot@github.com"
@@ -389,7 +393,14 @@ jobs:
           merge_branch_if_exists "debianmed-import-branch"
           merge_branch_if_exists "bioconductor-import-branch"
           merge_branch_if_exists "workflowhub-import-branch"
-          git push origin master
+          # Only push when at least one branch merged, for the same reason as
+          # in merge-bioconductor below.
+          git fetch origin master
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" ]; then
+            echo "Nothing to push, no import branch changed master."
+          else
+            git push origin HEAD:master
+          fi
   bioconductor-to-biotools:
     runs-on: ubuntu-latest
     needs:
@@ -438,6 +449,10 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          # Without this, checkout uses the run's head SHA, which is where
+          # master stood when the run started -- before merge-imports pushed.
+          ref: master
       - name: Merge bioconductor-to-biotools branch
         run: |
           git config --local user.email "tpe-bot@github.com"
@@ -449,7 +464,15 @@ jobs:
           else
             echo "Branch bioconductor-to-biotools-branch does not exist on the remote repository."
           fi
-          git push origin master
+          # Only push when the merge actually moved master forward. Pushing
+          # unconditionally sends whatever was checked out, which fails as a
+          # non-fast-forward whenever nothing was merged.
+          git fetch origin master
+          if [ "$(git rev-parse HEAD)" = "$(git rev-parse origin/master)" ]; then
+            echo "Nothing to push, master is unchanged."
+          else
+            git push origin HEAD:master
+          fi
   clean-branches:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
`merge-bioconductor` [failed](https://github.com/research-software-ecosystem/content/actions/runs/33109115639) in the last import run:

```
! [rejected]  master -> master (fetch first)
error: failed to push some refs to 'https://github.com/research-software-ecosystem/content'
```

Two faults combine.

**1. Both merge jobs check out a stale commit.** `actions/checkout` with no `ref:` resolves to the run's head SHA — where `master` stood when the run was dispatched. In that run:

| | |
|---|---|
| run `head_sha` (what checkout used) | `f16357a` |
| `master` after `merge-imports` pushed | `3e33cb6` |

So `merge-bioconductor` was working from a commit six merges behind.

**2. `git push origin master` sat outside the `if` guarding the merge.** `bioconductor-to-biotools` had been skipped, so `bioconductor-to-biotools-branch` did not exist, nothing was merged — and the job pushed the stale checkout it started from anyway. That is a non-fast-forward, hence the rejection.

### The fix

Both merge jobs now:

- check out `ref: master`, so they operate on the current tip;
- push only when the merge actually moved `master` forward, comparing `HEAD` against a freshly fetched `origin/master`.

If `HEAD` has diverged rather than advanced, the push still fails loudly — the right outcome, and better than forcing.

`merge-imports` gets the same treatment. It survived this run only because it happened to merge branches descended from the SHA it checked out; with no import branches present it would have pushed a stale ref exactly as `merge-bioconductor` did.

### How the chain started

The `workflowhub` job failed. `merge-imports` carries `if: always()` and succeeded — but `bioconductor-to-biotools` has the default `if: success()` and was **skipped**, which is consistent with `success()` being evaluated over the whole upstream graph rather than only the direct `needs`. That skip is what left `merge-bioconductor` with nothing to merge, at which point fault 2 fired.

research-software-ecosystem/utils#58 fixes the original WorkflowHub timeout. This PR fixes the latent bug it exposed, which would have surfaced eventually on its own.

Verified: YAML parses, both `run` blocks pass `bash -n`, both checkouts now pin `ref: master`, and no unconditional `git push origin master` remains in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
