### PR TITLE
Run gh2biotools on imported Bioconductor data

### DIFF
--- a/.github/workflows/biotools-gh2biotools.yml
+++ b/.github/workflows/biotools-gh2biotools.yml
@@ -6,15 +6,37 @@ on:
       - 'data/**/*.biotools.json'
     branches:
       - master
+  workflow_call:
+    inputs:
+      files:
+        description: Space-separated list of .biotools.json files to sync with bio.tools
+        type: string
+        required: true
+      ref:
+        description: Commit to check out — the commit that introduced the changes
+        type: string
+        required: true
+      base:
+        description: Commit to compare against for the protected-field check (defaults to the parent of the checked-out commit)
+        type: string
+        required: false
+        default: ''
+
+# bio.tools writes are serialised: an import run and a human push must not
+# hit the API at the same time.
+concurrency:
+  group: gh2biotools
+  cancel-in-progress: false
 
 jobs:
   run-gh2biotools:
     runs-on: ubuntu-latest
-    if: github.actor != 'biotools-bot'
-    
+    if: github.event_name != 'push' || github.actor != 'biotools-bot'
+
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ inputs.ref || github.sha }}
           sparse-checkout: '**/*.biotools.json'
           sparse-checkout-cone-mode: false
           fetch-depth: 2
@@ -22,14 +44,69 @@ jobs:
 
       - name: check changes to biotools.json files
         id: changes
+        if: github.event_name == 'push'
         uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
         with:
-          files: | 
+          files: |
             **/*.biotools.json
 
 
-      - name: validate allowed fields
+      - name: resolve file list and base commit
+        id: resolve
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUSH_FILES: ${{ steps.changes.outputs.all_changed_files }}
+          PUSH_BASE: ${{ github.event.before }}
+          INPUT_FILES: ${{ inputs.files }}
+          INPUT_BASE: ${{ inputs.base }}
         run: |
+          if [ "$EVENT_NAME" = "push" ]; then
+            files="$PUSH_FILES"
+            base="$PUSH_BASE"
+          else
+            files="$INPUT_FILES"
+            base="$INPUT_BASE"
+            [ -n "$base" ] || base="$(git rev-parse HEAD^)"
+          fi
+
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          echo "base=$base" >> "$GITHUB_OUTPUT"
+          echo "$(echo $files | wc -w) file(s) to process, base commit $base"
+
+
+      - name: make base commit available
+        if: steps.resolve.outputs.files != ''
+        env:
+          BASE: ${{ steps.resolve.outputs.base }}
+        run: |
+          # The checkout is shallow (the repository is several GB), so the base
+          # commit of a multi-commit push is usually not present. Fetch just it.
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base commit (new branch) — protected-field check will be skipped."
+            exit 0
+          fi
+
+          if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            git fetch --depth=1 origin "$BASE"
+          fi
+
+          if ! git cat-file -e "$BASE^{commit}" 2>/dev/null; then
+            echo "::error ::Base commit $BASE could not be fetched; refusing to skip the protected-field check."
+            exit 1
+          fi
+
+
+      - name: validate allowed fields
+        if: steps.resolve.outputs.files != ''
+        env:
+          BASE: ${{ steps.resolve.outputs.base }}
+          FILES: ${{ steps.resolve.outputs.files }}
+        run: |
+          if [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No base commit to compare against — skipping."
+            exit 0
+          fi
+
           echo "Validating fields in changed .biotools.json files..."
           PROTECTED_FIELDS=(
             "biotoolsID"
@@ -50,21 +127,30 @@ jobs:
 
           failed=false
 
-          for file in $(echo "${{ steps.changes.outputs.all_changed_files }}"); do
+          # $FILES is a space-separated list; word splitting is intended.
+          for file in $FILES; do
             echo "Checking $file..."
-        
-            git show ${{ github.event.before }}:$file > old.json || continue
-            cat $file > new.json
+
+            if ! git cat-file -e "$BASE:$file" 2>/dev/null; then
+              echo "  new file — no previous version to compare against"
+              continue
+            fi
+
+            git show "$BASE:$file" > old.json
 
             for field in "${PROTECTED_FIELDS[@]}"; do
-              old_val=$(jq -e ".$field" old.json 2>/dev/null || echo "")
-              new_val=$(jq -e ".$field" new.json 2>/dev/null || echo "")
+              # Wrapping the value in an array keeps "absent" distinguishable
+              # from "present but null" — bare .field returns null for both.
+              old_val=$(jq -c --arg f "$field" 'if has($f) then [.[$f]] else "absent" end' old.json)
+              new_val=$(jq -c --arg f "$field" 'if has($f) then [.[$f]] else "absent" end' "$file")
               if [ "$old_val" != "$new_val" ]; then
                 echo "❌ Field '$field' has been modified in $file"
                 failed=true
               fi
             done
           done
+
+          rm -f old.json
 
           if [ "$failed" = true ]; then
             echo "::error ::One or more not allowed fields have been modified."
@@ -75,6 +161,7 @@ jobs:
 
 
       - name: checkout utils repo
+        if: steps.resolve.outputs.files != ''
         uses: actions/checkout@v4
         with:
           repository: research-software-ecosystem/utils
@@ -85,27 +172,36 @@ jobs:
 
 
       - name: set up Python
-        uses: actions/setup-python@v4
+        if: steps.resolve.outputs.files != ''
+        uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
 
       - name: install dependencies
+        if: steps.resolve.outputs.files != ''
         working-directory: content-ecosystem-utils/scripts/runbiotools
         run: |
           pip3 install -r requirements.txt
 
 
       - name: run gh2biotools.py script
+        if: steps.resolve.outputs.files != ''
         env:
           BIOTOOLS_API_TOKEN: ${{ secrets.BIOTOOLS_API_TOKEN }}
+          FILES: ${{ steps.resolve.outputs.files }}
         run: |
-          changed_files="${{ steps.changes.outputs.all_changed_files }}"
+          set -o pipefail
 
-          command="python content-ecosystem-utils/scripts/runbiotools/gh2biotools.py"
+          # --files takes nargs="+", so the list must reach argparse as separate
+          # arguments. Quoting it passes the whole list as a single filename,
+          # which only ever worked when exactly one file had changed.
+          python content-ecosystem-utils/scripts/runbiotools/gh2biotools.py \
+            --files $FILES 2>&1 | tee gh2biotools.log
 
-          if [[ -n "$changed_files" ]]; then
-            command="$command --files \"$changed_files\""
+          # gh2biotools.py reports per-tool failures in its summary but always
+          # exits 0. Surface them so a partly-failed sync is not a green run.
+          if grep -qE 'Tools failed[^:]*: [1-9]' gh2biotools.log; then
+            echo "::error ::gh2biotools reported failures — see the summary above."
+            exit 1
           fi
-
-          eval "$command"

--- a/.github/workflows/import.yaml
+++ b/.github/workflows/import.yaml
@@ -396,6 +396,7 @@ jobs:
       - merge-imports
     outputs:
       commit_hash: ${{ steps.commit-and-push-bioconductor-to-biotools.outputs.commit_hash }}
+      files: ${{ steps.changed-biotools-files.outputs.files }}
     steps:
     - name: checkout contents repository
       uses: actions/checkout@v4
@@ -420,6 +421,18 @@ jobs:
       with:
         repo-user: ${{ secrets.GITHUB_USER }}
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Collect changed biotools files
+      id: changed-biotools-files
+      run: |
+        # Recorded before the commit step, while the tree is still dirty.
+        # -uall so that files in newly created tool directories are listed
+        # individually rather than collapsed into the directory.
+        files=$(git status --porcelain=v1 -uall -- data/ \
+                | sed 's/^...//' \
+                | grep '\.biotools\.json$' \
+                | tr '\n' ' ')
+        echo "files=$files" >> "$GITHUB_OUTPUT"
+        echo "$(echo $files | wc -w) changed .biotools.json file(s)."
     - name: Commit and Push Changes
       id: commit-and-push-bioconductor-to-biotools
       uses: stefanzweifel/git-auto-commit-action@v5
@@ -435,10 +448,13 @@ jobs:
     needs:
       - bioconductor-to-biotools
     if: always()
+    outputs:
+      sha: ${{ steps.merge-bioconductor-branch.outputs.sha }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
       - name: Merge bioconductor-to-biotools branch
+        id: merge-bioconductor-branch
         run: |
           git config --local user.email "tpe-bot@github.com"
           git config --local user.name "Tools Platform Ecosystem bot"
@@ -450,6 +466,22 @@ jobs:
             echo "Branch bioconductor-to-biotools-branch does not exist on the remote repository."
           fi
           git push origin master
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+  gh2biotools:
+    # Pushes made with GITHUB_TOKEN do not start workflow runs, so the master
+    # push above can never trigger biotools-gh2biotools.yml via `on: push`.
+    # Call it directly instead, scoped to the files this run actually converted
+    # — the merge commit also carries data imported *from* bio.tools, which
+    # must not be pushed back.
+    needs:
+      - bioconductor-to-biotools
+      - merge-bioconductor
+    if: needs.bioconductor-to-biotools.outputs.files != ''
+    uses: ./.github/workflows/biotools-gh2biotools.yml
+    with:
+      files: ${{ needs.bioconductor-to-biotools.outputs.files }}
+      ref: ${{ needs.merge-bioconductor.outputs.sha }}
+    secrets: inherit
   clean-branches:
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
## Problem

The weekly `import data` run converts Bioconductor metadata into `.biotools.json` files and pushes them to `master`, but `biotools-gh2biotools.yml` never runs, so none of it reaches bio.tools.

The cause is GitHub's recursion guard. The `merge-imports` and `merge-bioconductor` jobs use a plain `actions/checkout@v4`, which persists `GITHUB_TOKEN` as the push credential, and then `git push origin master`. Per the [events reference](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows): "With the exception of `workflow_dispatch` and `repository_dispatch`, other `GITHUB_TOKEN`-triggered events do not create workflow runs at all."

So the push succeeds — this is not a permissions problem — but `on: push` never fires.

Evidence: the 2026-08-28 import landed `fbd08f8 convert bioconductor to biotools format` (300 files under `data/**/*.biotools.json`, on `master`) and no push-event run followed. `gh2biotools` last ran on 2026-03-19, on a hand-authored commit. Every push to `master` from the pipeline is attributed to `github-actions[bot]`.

## Approach

Rather than fix the trigger, this stops using a git push as the message bus. The import already knows exactly which files it changed, so it calls `gh2biotools` directly as a job.

That is also **more correct than push-triggering would be**. The merge commit carries changes from every import source — including data just pulled *from* bio.tools by the `biotools` job. A push-triggered run would push all of it straight back at bio.tools. Scoping the call to the `bioconductor-to-biotools` job's own diff is not something the `paths:` filter can express.

No PAT and no GitHub App: the reusable-workflow call needs no credential at all.

## Changes

**`biotools-gh2biotools.yml`**
- Adds a `workflow_call` trigger with `files`, `ref`, and `base` inputs. The existing `on: push` path is unchanged in behaviour.
- Adds `concurrency: gh2biotools` so an import run and a human push cannot write to the bio.tools API simultaneously.
- Bumps `actions/setup-python` v4 → v5 (v4 is node16; actionlint flags it as too old to run).

**`import.yaml`**
- `bioconductor-to-biotools` records the converted file list (before the commit step, while the tree is dirty) and exposes it as a job output.
- `merge-bioconductor` exposes the SHA it pushed.
- New `gh2biotools` job calls the reusable workflow with that file list, pinned to that SHA.

## Bugs found and fixed along the way

**`--files` was passed quoted, so multi-file runs were broken.** `gh2biotools.py` declares `--files` with `nargs="+"`, but the workflow built `--files "$changed_files"` and `eval`'d it, so argparse received the entire space-separated list as a *single* filename:

```
OLD: argparse received 1 path(s):
    'data/a/a.biotools.json data/b/b.biotools.json data/c/c.biotools.json'
NEW: argparse received 3 path(s):
    'data/a/a.biotools.json' ...
```

This has never worked for more than one file at a time — consistent with both successful runs in the history being single-file commits. It would have failed immediately on a 300-file import.

**The protected-field check failed open.** `git show ${{ github.event.before }}:$file || continue` silently skipped validation whenever the base commit was unreachable — which, with `fetch-depth: 2`, is the normal case for a multi-commit push. Now the base commit is explicitly fetched (`git fetch --depth=1`), the job fails if it cannot be obtained, and genuinely new files are detected with `git cat-file -e` instead of being conflated with fetch failures.

The comparison is also now exact: `jq 'if has($f) then [.[$f]] else "absent" end'` distinguishes an absent field from one present-but-null, which the previous `jq -e .$field` could not.

**Untracked files in new directories would have been dropped.** `git status --porcelain` collapses new directories to `data/newtool/`, which a `\.biotools\.json$` filter discards. The collection step uses `-uall`. Verified:

```
default: ?? data/newtool/
-uall:   ?? data/newtool/newtool.biotools.json
```

**Partial failures were invisible.** `gh2biotools.py` records per-tool failures in its summary but always exits 0, so a run where all 300 tools failed would have been green. The step now fails if the summary reports a non-zero failure count.

## Verification

- `actionlint` clean on both files.
- The file-collection, protected-field, and failure-gate shell logic was exercised against a scratch git repo — including a tampered `owner` (correctly fails), a licence-only change (correctly passes), a new tool directory, and a null → absent field change.
- The conversion's actual output was checked against the protected-field list: `fbd08f8` changes `description`, `homepage`, `license`, `credit`, `publication`, and `version`, and leaves `lastUpdate`, `owner`, `validated`, and `editPermission` untouched. Validation should pass on real import output.

`fetch-depth: 0` was considered for the base-commit problem and rejected — the repository is ~5.6 GB.

## Worth a reviewer's attention

**This turns on ~300 bio.tools API writes on the next scheduled import.** `gh2biotools.py` has no rate limiting, no retry, and no backoff — each file is a `GET`, then a `validate`, then a `PUT`. Suggest merging this and then running `import data` manually once to watch the first sync, rather than letting the Sunday cron be the first real run. Hardening the script belongs in `research-software-ecosystem/utils`, not here.

**The failure gate greps the script's log output**, which is brittle if `print_summary` is reworked. It is a self-contained final step and easy to drop if you would rather fix the exit code upstream instead.

**`secrets.GITHUB_USER` and `secrets.GITHUB_TOKEN`** are referenced throughout `import.yaml` but neither exists — GitHub reserves the `GITHUB_` prefix, so `secrets.GITHUB_TOKEN` always resolves to the built-in token regardless of intent, and there is no `GITHUB_USER` secret in this repo. Left alone here since it is orthogonal, but it may not be doing what it looks like it does.

There is also an unused `REPO_TOKEN` secret in this repo, referenced by no workflow — presumably created for exactly this problem. This PR makes it unnecessary.
