### PR TITLE
Treat collectionID as append-only in the protected-field check

### DIFF
--- a/.github/workflows/biotools-gh2biotools.yml
+++ b/.github/workflows/biotools-gh2biotools.yml
@@ -143,10 +143,23 @@ jobs:
               # from "present but null" — bare .field returns null for both.
               old_val=$(jq -c --arg f "$field" 'if has($f) then [.[$f]] else "absent" end' old.json)
               new_val=$(jq -c --arg f "$field" 'if has($f) then [.[$f]] else "absent" end' "$file")
-              if [ "$old_val" != "$new_val" ]; then
-                echo "❌ Field '$field' has been modified in $file"
-                failed=true
+              [ "$old_val" = "$new_val" ] && continue
+
+              # collectionID is append-only rather than frozen: an importer may
+              # add its own collection — bc2bt adds "BioConductor" by design —
+              # but nothing may drop a collection an entry already carries.
+              if [ "$field" = "collectionID" ]; then
+                removed=$(jq -rn --slurpfile a old.json --slurpfile b "$file" \
+                  '(($a[0].collectionID // []) - ($b[0].collectionID // [])) | join(", ")')
+                if [ -n "$removed" ]; then
+                  echo "❌ collectionID entries removed from $file: $removed"
+                  failed=true
+                fi
+                continue
               fi
+
+              echo "❌ Field '$field' has been modified in $file"
+              failed=true
             done
           done
 


### PR DESCRIPTION
## What broke

Run [33271224130](https://github.com/research-software-ecosystem/content/actions/runs/33271224130) — the first `import data` run after #2132 wired `gh2biotools` into the pipeline — failed at `validate allowed fields`. Every other job succeeded; the import completed and pushed to master. What was blocked was the bio.tools API write.

230 files failed, all on one field: `collectionID`.

## Why

The Bioconductor converter adds `"BioConductor"` to `collectionID` deliberately — `bc2bt/updater.py`:

```python
existing_collections = set(existing_data.get("collectionID", []))
existing_collections.add("BioConductor")
merged_data["collectionID"] = sorted(list(existing_collections))
```

But `collectionID` sits in this workflow's `PROTECTED_FIELDS`. The two rules contradict each other outright.

It never surfaced before because `gh2biotools` had only ever run on hand-authored single-file commits — the protected-field check had never once seen conversion output.

## The change

`collectionID` becomes append-only rather than frozen: adding a collection is allowed, removing one still fails. That keeps the guard's actual intent — nobody may strip a curated collection from an entry — while permitting what the importer does by design. Every other protected field is unchanged and still strictly frozen.

All 230 failures in that run were strictly additive; none removed anything:

```
213  absent                  ->  ["BioConductor"]
  3  ["de.NBI"]              ->  ["BioConductor","de.NBI"]
  1  ["KU Leuven","VIB"]     ->  ["BioConductor","KU Leuven","VIB"]
  1  ["EBI Tools","Job Dispatcher Tools","MUSCLE"]
                             ->  ["BioConductor","EBI Tools","Job Dispatcher Tools","MUSCLE"]
  …
```

## Verification

The patched loop was run against 40 of the real file pairs from the failed run, fetched at the run's own base (`3c55011e`) and head (`00bc4b88`) commits:

- **0 of 40 fail** under the patch (was 40 of 40).
- Control — dropping `de.NBI` to add `BioConductor` — still rejected: `collectionID entries removed: de.NBI`.
- Control — tampering with `owner` — still rejected.

`actionlint` clean.

## Note on the alternative

Deleting `collectionID` from `PROTECTED_FIELDS` would also unblock the run, but it drops the protection on the human-PR path, which is where it earns its keep. Append-only keeps both.

## Related

A separate issue this exposed: 5 entries now carry both `"BioConductor"` and `"Bioconductor"`, because the converter adds its own spelling without checking for a case variant already present. That is fixed in research-software-ecosystem/utils — this PR intentionally lets such additions through, since they are additions.
